### PR TITLE
✨ 메인페이지 내 스케쥴 컴포넌트 추가

### DIFF
--- a/src/app/page.1280.scss
+++ b/src/app/page.1280.scss
@@ -1,4 +1,5 @@
 @import '@/components/common/button/Button.scss';
+@import '@/styles/fonts.scss';
 
 .pg-typo-container {
   margin-top: 210px;
@@ -18,4 +19,9 @@
 
 .pg-team-button-container {
   margin: 332px 0px 16px;
+}
+
+.pg-schedule-head {
+  @include font-style($sf_pro, 700, 64px, 72px, 0px);
+  margin: 362px - 16px 0px 16px;
 }

--- a/src/app/page.scss
+++ b/src/app/page.scss
@@ -1,3 +1,5 @@
+@import '@/styles/fonts.scss';
+
 .pg-typo-container {
   margin-top: 58px;
 }
@@ -11,6 +13,11 @@
 }
 
 .pg-team-button-container {
+  margin: 120px 0px 8px;
+}
+
+.pg-schedule-head {
+  @extend .sf_heading_3;
   margin: 120px 0px 8px;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Typo from '@/components/Home/Typo';
 import About from '@/components/Home/About';
 import OneTeam from '@/components/Home/OneTeam';
+import Schedule from '@/components/Home/Schedule';
 import PageRouterButton from '@/components/Home/PageRouterButton';
 
 import Button from '@/components/common/button/Button';
@@ -34,6 +35,8 @@ export default function Home() {
         <PageRouterButton label="One team" href="/about" />
       </div>
       <OneTeam />
+      <h3 className="pg-schedule-head white">9th Schedule</h3>
+      <Schedule />
       <div>
         <div className="sf_display_1">Hello! prography-hompage</div>
         <Link href="/test">공통컴포넌트 보러 가기</Link>

--- a/src/components/Home/About.1280.scss
+++ b/src/components/Home/About.1280.scss
@@ -14,6 +14,7 @@
   }
 
   &:last-child {
+    margin-top: 0px;
     margin-left: 100px;
   }
 }

--- a/src/components/Home/Schedule.1280.scss
+++ b/src/components/Home/Schedule.1280.scss
@@ -1,0 +1,25 @@
+@import '@/styles/fonts.scss';
+
+.break-point {
+  display: block;
+}
+
+.pg-schedule-text {
+  @include font-style($pretendard, 400, 20px, 32px, -0.25px);
+  margin: 16px 0px 56px;
+}
+
+.pg-schedule-wrapper {
+  display: flex;
+  margin-bottom: 44px;
+
+  .pg-schedule-date {
+    width: 211px;
+    @include font-style($sf_pro, 700, 24px, 32px, 0px);
+  }
+
+  .pg-schedule-name {
+    @include font-style($pretendard, 400, 24px, 32px, -0.25px);
+    margin-top: 0px;
+  }
+}

--- a/src/components/Home/Schedule.scss
+++ b/src/components/Home/Schedule.scss
@@ -1,0 +1,32 @@
+@import '@/styles/fonts.scss';
+
+.break-point {
+  display: none;
+}
+
+.pg-schedule-text {
+  @extend .pre_heading_6;
+  margin: 8px 0px 40px;
+  display: inline-block;
+}
+
+.pg-schedule-wrapper {
+  margin-bottom: 24px;
+
+  &:last-child {
+    margin-bottom: 0px;
+  }
+
+  .pg-schedule-date {
+    @extend .sf_heading_6;
+  }
+
+  .pg-schedule-name {
+    @extend .pre_caption_1;
+    margin-top: 4px;
+  }
+}
+
+@media (min-width: 1280px) {
+  @import './Schedule.1280.scss';
+}

--- a/src/components/Home/Schedule.tsx
+++ b/src/components/Home/Schedule.tsx
@@ -1,0 +1,52 @@
+import './Schedule.scss';
+
+interface TimeTableProps {
+  startDate: string;
+  endDate: string;
+  name: string;
+}
+
+const Schedule = () => {
+  // toDo: api 교체 필요
+  const timeTable: TimeTableProps[] = [
+    {
+      startDate: '01.13',
+      endDate: '01.24',
+      name: '9기 서류 제출',
+    },
+    {
+      startDate: '01.30',
+      endDate: '02.04',
+      name: '사전 과제 기간',
+    },
+    {
+      startDate: '02.17',
+      endDate: '02.14',
+      name: '인터뷰 진행',
+    },
+    {
+      startDate: '02.19',
+      endDate: '02.19',
+      name: '결과 발표',
+    },
+  ];
+  return (
+    <>
+      <div className="pg-schedule-text white">
+        프로그라피는 정규 세션을 중심으로 여러 Culture Program을 진행합니다.{' '}
+        <div className="break-point" />
+        지원 관련 문의는 이메일 또는 Contact 페이지의 FAQ를 확인해 주세요.
+      </div>
+      {timeTable.map(({ startDate, endDate, name }) => (
+        <div className="pg-schedule-wrapper" key={startDate + name}>
+          <p className="pg-schedule-date white">
+            {startDate} {startDate !== endDate && `- ${endDate}`}
+          </p>
+          <p className="pg-schedule-name white">{name}</p>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default Schedule;


### PR DESCRIPTION
# Feature Request

👉 기능 설명

- 이전 About component에서 pc버전에서 margin이 하나 어긋난거 있어서 수정했습니다.
- 메인페이지에서 schedule component 추가 했습니다.

👉 요청 및 질문사항

- 날짜는 api로 날아올 예정이라 일단 dummy data형식으로 넣었습니다.
- api response 가 id, startDate, endDate, name 으로 날아오고 종료일자가 없는 경우 시작일자랑 종료일자가 동일한 값으로 응답받게 되어 있습니다. (범우형이랑 논의 완료)

📷 스크린샷
<img width="634" alt="스크린샷 2023-12-10 오후 11 44 07" src="https://github.com/prography-dev/prography-homepage-frontend/assets/52899141/2e4b5b31-88cb-4f1f-b857-f523b1d3426a">

